### PR TITLE
Download EPUB version of entries: depends on server version

### DIFF
--- a/files/config-dist.json
+++ b/files/config-dist.json
@@ -6,4 +6,5 @@
     "secret_key": "",
     "login": "",
     "password": "",
+    "force_download_epub": false
 }

--- a/src/api/wallabag_api.cpp
+++ b/src/api/wallabag_api.cpp
@@ -182,10 +182,10 @@ void WallabagApi::loadRecentArticles(EntryRepository repository, time_t lastSync
 			DEBUG("Server version (%s) is older than 2.2 => we will not attempt to download EPUB version of entries", serverVersion.c_str());
 			canDownloadEpub = false;
 
-#ifdef PLOP_FORCE_EPUB_DOWNLOAD_EVEN_IF_OLD_SERVER
-			DEBUG("WARNING: #define PLOP_FORCE_EPUB_DOWNLOAD_EVEN_IF_OLD_SERVER is set => WE WILL ATTEMPT TO DOWNLOAD EPUB version of entries anyway!");
-			canDownloadEpub = true;
-#endif
+			if (config.force_download_epub) {
+				DEBUG("WARNING: 'force_download_epub' is set in configuration => WE WILL ATTEMPT TO DOWNLOAD EPUB version of entries anyway!");
+				canDownloadEpub = true;
+			}
 		}
 		else {
 			DEBUG("Server version (%s) is greater than 2.2 => we will attempt to download EPUB version of entries", serverVersion.c_str());

--- a/src/api/wallabag_api.cpp
+++ b/src/api/wallabag_api.cpp
@@ -181,6 +181,11 @@ void WallabagApi::loadRecentArticles(EntryRepository repository, time_t lastSync
 		if (strverscmp(serverVersion.c_str(), "2.2") < 0) {
 			DEBUG("Server version (%s) is older than 2.2 => we will not attempt to download EPUB version of entries", serverVersion.c_str());
 			canDownloadEpub = false;
+
+#ifdef PLOP_FORCE_EPUB_DOWNLOAD_EVEN_IF_OLD_SERVER
+			DEBUG("WARNING: #define PLOP_FORCE_EPUB_DOWNLOAD_EVEN_IF_OLD_SERVER is set => WE WILL ATTEMPT TO DOWNLOAD EPUB version of entries anyway!");
+			canDownloadEpub = true;
+#endif
 		}
 		else {
 			DEBUG("Server version (%s) is greater than 2.2 => we will attempt to download EPUB version of entries", serverVersion.c_str());

--- a/src/api/wallabag_api.h
+++ b/src/api/wallabag_api.h
@@ -32,6 +32,8 @@ public:
 
 	void downloadEpub(EntryRepository &repository, Entry &entry, gui_update_progressbar progressbarUpdater, int percent);
 
+	void fetchServerVersion(gui_update_progressbar progressbarUpdater);
+
 private:
 	void syncOneEntryToServer(EntryRepository repository, Entry &entry);
 	static size_t _curlWriteCallback(char *ptr, size_t size, size_t nmemb, void *userdata);
@@ -56,6 +58,8 @@ private:
 	// For loadRecentArticles
 	int json_string_len;
 	char *json_string;
+
+	std::string serverVersion;
 };
 
 

--- a/src/api/wallabag_config.h
+++ b/src/api/wallabag_config.h
@@ -12,6 +12,7 @@ public:
 	std::string client_id;
 	std::string secret_key;
 	std::string login, password;
+	bool force_download_epub;
 };
 
 

--- a/src/api/wallabag_config_loader.cpp
+++ b/src/api/wallabag_config_loader.cpp
@@ -108,6 +108,8 @@ WallabagConfig WallabagConfigLoader::load(void)
 		ERROR("Entry 'password' not found in %s", CONFIG_FILE);
 	}
 
+	config.force_download_epub = json_object_get_boolean(json_object_object_get(obj, "force_download_epub"));
+
 	if (
 		(url == NULL || strlen(url) == 0)
 		|| (client_id == NULL || strlen(client_id) == 0)

--- a/src/defines.h
+++ b/src/defines.h
@@ -15,7 +15,4 @@
 #define PLOP_ENTRIES_CONTENT_DIRECTORY PLOP_BASE_DIRECTORY "/entries"
 #define PLOP_ENTRIES_EPUB_DIRECTORY PLOP_BASE_DIRECTORY "/entries-epub"
 
-// WARNING: Only define this to true if you have backported a patch to add 'export' to the API -- or if your wallabag instance's version is >= 2.2
-#define PLOP_FORCE_EPUB_DOWNLOAD_EVEN_IF_OLD_SERVER
-
 #endif /* DEFINES_H_ */

--- a/src/defines.h
+++ b/src/defines.h
@@ -15,4 +15,7 @@
 #define PLOP_ENTRIES_CONTENT_DIRECTORY PLOP_BASE_DIRECTORY "/entries"
 #define PLOP_ENTRIES_EPUB_DIRECTORY PLOP_BASE_DIRECTORY "/entries-epub"
 
+// WARNING: Only define this to true if you have backported a patch to add 'export' to the API -- or if your wallabag instance's version is >= 2.2
+#define PLOP_FORCE_EPUB_DOWNLOAD_EVEN_IF_OLD_SERVER
+
 #endif /* DEFINES_H_ */


### PR DESCRIPTION
Export of EPUB via the API is only supported with wallabag >= 2.2 ; so, don't try to download EPUB entries if the server is running an older version.

+ add a `#define` to download anyway (for those who backported the patch on their own instance ;-) )