### PR TITLE
Do not abort sync when a 404 occurs when pushing updates to server

### DIFF
--- a/src/api/wallabag_api.cpp
+++ b/src/api/wallabag_api.cpp
@@ -380,6 +380,19 @@ void WallabagApi::syncOneEntryToServer(EntryRepository repository, Entry &entry)
 	};
 
 	auto onFailure = [this] (CURLcode res, long response_code, CURL *curl) -> void {
+		if (response_code == 404) {
+			// Sync TO server occurs after we created an OAuth token and fetched recent entries,
+			// which means a 404 error is not likely caused by a wrong URL.
+			// Chances are pretty high a 404 here is caused by an entry that's been deleted on the server,
+			// but updated locally.
+			// => We do not consider this as an error and do not abort sync
+			INFO("API: syncOneEntryToServer(): we got a 404 error, but we consider this is OK (probably caused by an error that's been deleted on the server)");
+
+			// TODO flag local entry in some sort of way? At least so we don't try syncing it to the server again and again (and fail each time)
+
+			return;
+		}
+
 		ERROR("API: syncOneEntryToServer(): failure. HTTP response code = %ld", response_code);
 
 		std::ostringstream ss;


### PR DESCRIPTION
This is most likely caused by an entry that's been deleted on the server,
and should not abort the whole synchronisation.

Steps to reproduce the problem (before applying this PR):

 * Add an entry to wallabag
 * Sync from server to ereader
 * On the server, delete the entry
 * On the ereader, archive the same entry
 * Launch a sync on the ereader => when the ereader tries to push the "archived" info, it gets a 404 error and aborts sync.

@Ygster this relates to https://github.com/pmartin/plop-reader/issues/53 your created a few days ago ;-)
It's not a perfect fix, but should at least help until I implement a more complete solution.

As this bug is the most critical one that's been reported for version 0.2.0, I might release a v0.2.1 minor version with this fix...