### PR TITLE
Enqueue EPUB downloads, when syncing

### DIFF
--- a/src/api/wallabag_api.cpp
+++ b/src/api/wallabag_api.cpp
@@ -170,7 +170,7 @@ void WallabagApi::refreshOAuthToken(gui_update_progressbar progressbarUpdater)
 }
 
 
-void WallabagApi::loadRecentArticles(EntryRepository repository, time_t lastSyncTimestamp, gui_update_progressbar progressbarUpdater)
+void WallabagApi::loadRecentArticles(EntryRepository repository, EpubDownloadQueueRepository epubDownloadQueueRepository, time_t lastSyncTimestamp, gui_update_progressbar progressbarUpdater)
 {
 	this->refreshOAuthToken(progressbarUpdater);
 
@@ -279,9 +279,8 @@ void WallabagApi::loadRecentArticles(EntryRepository repository, time_t lastSync
 
 				// Download the EPUB for this entry -- as a first step, we can start by only downloading it when creating the local entry (and not when updating it)
 				if (canDownloadEpub && (!entry.local_is_archived || entry.local_is_starred)) {
-					// TODO download the EPUB synchronously, with a queue; and/or several download threads?
 					entry = repository.findByRemoteId(atoi(entry.remote_id.c_str()));
-					downloadEpub(repository, entry, progressbarUpdater, percentage);
+					enqueueEpubDownload(repository, entry, epubDownloadQueueRepository, progressbarUpdater, percentage);
 				}
 			}
 

--- a/src/api/wallabag_api.cpp
+++ b/src/api/wallabag_api.cpp
@@ -313,6 +313,28 @@ void WallabagApi::loadRecentArticles(EntryRepository repository, time_t lastSync
 	doHttpRequest(getUrl, getMethod, getData, beforeRequest, afterRequest, onSuccess, onFailure);
 
 	DEBUG("API: loadRecentArticles(): done");
+
+	startBackgroundDownloads(repository, epubDownloadQueueRepository);
+}
+
+
+void WallabagApi::enqueueEpubDownload(EntryRepository &repository, Entry &entry, EpubDownloadQueueRepository &epubDownloadQueueRepository, gui_update_progressbar progressbarUpdater, int percent)
+{
+	DEBUG("API: enqueueEpubDownload(): Enqueuing EPUB download for entry %d / %s", entry.id, entry.remote_id.c_str());
+
+	epubDownloadQueueRepository.enqueueDownloadForEntry(entry);
+
+	DEBUG("API: enqueueEpubDownload(): Enqueuing EPUB download for entry %d / %s: done", entry.id, entry.remote_id.c_str());
+}
+
+
+void WallabagApi::startBackgroundDownloads(EntryRepository &repository, EpubDownloadQueueRepository &epubDownloadQueueRepository)
+{
+	DEBUG("-> Starting downloading EPUB files in the background");
+
+	// TODO actually download EPUB files in the background + save them + update the corresponding entries ;-)
+
+	DEBUG("<- Done downloading EPUB files in the background");
 }
 
 

--- a/src/api/wallabag_api.h
+++ b/src/api/wallabag_api.h
@@ -11,6 +11,7 @@
 #include "wallabag_oauth_token.h"
 
 #include "../repositories/entry_repository.h"
+#include "../repositories/epub_download_queue_repository.h"
 
 #include "../log.h"
 #include "../exceptions.h"
@@ -29,6 +30,9 @@ public:
 	void loadRecentArticles(EntryRepository repository, time_t lastSyncTimestamp, gui_update_progressbar progressbarUpdater);
 
 	void syncEntriesToServer(EntryRepository repository, gui_update_progressbar progressbarUpdater);
+
+	void enqueueEpubDownload(EntryRepository &repository, Entry &entry, EpubDownloadQueueRepository &epubDownloadQueueRepository, gui_update_progressbar progressbarUpdater, int percent);
+	void startBackgroundDownloads(EntryRepository &repository, EpubDownloadQueueRepository &epubDownloadQueueRepository);
 
 	void downloadEpub(EntryRepository &repository, Entry &entry, gui_update_progressbar progressbarUpdater, int percent);
 

--- a/src/api/wallabag_api.h
+++ b/src/api/wallabag_api.h
@@ -27,7 +27,7 @@ public:
 	void createOAuthToken(gui_update_progressbar progressbarUpdater);
 	void refreshOAuthToken(gui_update_progressbar progressbarUpdater);
 
-	void loadRecentArticles(EntryRepository repository, time_t lastSyncTimestamp, gui_update_progressbar progressbarUpdater);
+	void loadRecentArticles(EntryRepository repository, EpubDownloadQueueRepository epubDownloadQueueRepository, time_t lastSyncTimestamp, gui_update_progressbar progressbarUpdater);
 
 	void syncEntriesToServer(EntryRepository repository, gui_update_progressbar progressbarUpdater);
 

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -77,7 +77,7 @@ void Application::loadRecentArticles()
 	DEBUG("Last sync TS = %ld", lastSyncTimestamp);
 
 	try {
-		wallabag_api.loadRecentArticles(entryRepository, lastSyncTimestamp, [](const char *text, int percent, void *context) {
+		wallabag_api.loadRecentArticles(entryRepository, epubDownloadQueueRepository, lastSyncTimestamp, [](const char *text, int percent, void *context) {
 			app.gui.updateProgressBar(text, percent);
 		});
 

--- a/src/application.h
+++ b/src/application.h
@@ -13,6 +13,7 @@
 #include "gui/gui.h"
 
 #include "repositories/entry_repository.h"
+#include "repositories/epub_download_queue_repository.h"
 
 
 #include <sstream>
@@ -27,7 +28,7 @@ public:
 	enum entries_mode {MODE_UNREAD=1, MODE_ARCHIVED, MODE_STARRED};
 	enum reading_format {FORMAT_HTML=1, FORMAT_EPUB};
 
-	Application() : entryRepository(db), gui(*this) {
+	Application() : entryRepository(db), epubDownloadQueueRepository(db), gui(*this) {
 		db.open();
 		pageNum = 1;
 		numPerPage = 8;
@@ -71,6 +72,7 @@ private:
 	Database db;
 	WallabagApi wallabag_api;
 	EntryRepository entryRepository;
+	EpubDownloadQueueRepository epubDownloadQueueRepository;
 	Gui gui;
 
 	entries_mode mode;


### PR DESCRIPTION
Second step for downloading EPUB files in the background, see #57

Here, instead of downloading EPUB files during sync, we just enqueue them for download at a later time.
And set up the "start download" method (which does nothing for now, ofc)