### PR TITLE
Half hide empty entries

### DIFF
--- a/src/api/wallabag_api.cpp
+++ b/src/api/wallabag_api.cpp
@@ -282,7 +282,11 @@ void WallabagApi::loadRecentArticles(EntryRepository repository, EpubDownloadQue
 				repository.persist(entry);
 
 				// Download the EPUB for this entry -- as a first step, we can start by only downloading it when creating the local entry (and not when updating it)
-				if (canDownloadEpub && (!entry.local_is_archived || entry.local_is_starred)) {
+				if (
+					canDownloadEpub
+					&& (!entry.local_is_archived || entry.local_is_starred)
+					&& !entry.is_empty
+				) {
 					entry = repository.findByRemoteId(atoi(entry.remote_id.c_str()));
 					enqueueEpubDownload(repository, entry, epubDownloadQueueRepository, progressbarUpdater, percentage);
 				}

--- a/src/api/wallabag_entities_factory.cpp
+++ b/src/api/wallabag_entities_factory.cpp
@@ -55,6 +55,12 @@ Entry WallabagEntitiesFactory::createEntryFromJson(json_object *item)
 	entry.local_content_file_html = std::string();
 	entry.local_content_file_epub = std::string();
 
+	if (entry.title == "No title found" && entry.reading_time <= 0) {
+		entry.is_empty = true;
+	} else {
+		entry.is_empty = false;
+	}
+
 	return entry;
 }
 

--- a/src/database/database.h
+++ b/src/database/database.h
@@ -45,6 +45,7 @@ private:
 	void migration_002_createEntriesTable();
 	void migration_003_createIndexesOnEntries();
 	void migration_004_createEpubDownloadQueueTable();
+	void migration_005_addIsEmptyFieldOnEntries();
 
 	void insertInternal(std::string key, std::string value);
 	void updateInternal(std::string key, std::string value);

--- a/src/entities/entry.h
+++ b/src/entities/entry.h
@@ -35,6 +35,8 @@ public:
 	std::string local_content_file_html;
 	std::string local_content_file_epub;
 
+	bool is_empty;
+
 	bool _isChanged;
 };
 

--- a/src/gui/gui_list_item_entry.cpp
+++ b/src/gui/gui_list_item_entry.cpp
@@ -23,18 +23,18 @@ void GuiListItemEntry::draw(bool clearBeforeDraw, bool updateScreen)
 		return;
 	}
 
-	SetFont(titleFont, BLACK);
+	SetFont(titleFont, entry.is_empty ? DGRAY : BLACK);
 	snprintf(buffer, sizeof(buffer), "%s", entry.title.c_str());
 	DrawString(90, yy, buffer);
 	yy += titleFont->height;
 
 
-	SetFont(infosFont, BLACK);
+	SetFont(infosFont, entry.is_empty ? LGRAY : BLACK);
 	snprintf(buffer, sizeof(buffer), "#%d/%s a%d/%d *%d/%d u%d/%d t%d %s", entry.id, entry.remote_id.c_str(), entry.local_is_archived, entry.remote_is_archived, entry.local_is_starred, entry.remote_is_starred, entry.local_updated_at, entry.remote_updated_at, (int)ceil((float)entry.reading_time/(float)60), (entry.local_content_file_epub != "" ? "E" : "H"));
 	DrawString(90, yy, buffer);
 	yy += infosFont->height;
 
-	SetFont(infosFont, BLACK);
+	SetFont(infosFont, entry.is_empty ? LGRAY : BLACK);
 	snprintf(buffer, sizeof(buffer), "%s", entry.url.c_str());
 	DrawString(90, yy, buffer);
 	yy += infosFont->height;


### PR DESCRIPTION
On this PR :

 * Add an `is_empty` attribute on local entries
 * Set it when fetching an entry from server (based on the "no title" set by wallabag + duration = 0)
 * Do not attempt to fetch EPUB file for empty entries
 * DIsplay empty entries in gray instead of black

I've chosen not to fully-hide empty entries, as the user might be surprised not to find one in the list -- and on my instance / the posts I read, I don't have too many empty entries.

fix #48