### PR TITLE
Use dark gray (instead of black) for items infos and URLs

### DIFF
--- a/src/gui/gui_list_item_entry.cpp
+++ b/src/gui/gui_list_item_entry.cpp
@@ -28,12 +28,12 @@ void GuiListItemEntry::draw(bool clearBeforeDraw, bool mustUpdateScreen, bool hi
 	yy += titleFont->height;
 
 
-	SetFont(infosFont, entry.is_empty ? LGRAY : BLACK);
+	SetFont(infosFont, entry.is_empty ? LGRAY : DGRAY);
 	snprintf(buffer, sizeof(buffer), "#%d/%s a%d/%d *%d/%d u%d/%d t%d %s", entry.id, entry.remote_id.c_str(), entry.local_is_archived, entry.remote_is_archived, entry.local_is_starred, entry.remote_is_starred, entry.local_updated_at, entry.remote_updated_at, (int)ceil((float)entry.reading_time/(float)60), (entry.local_content_file_epub != "" ? "E" : "H"));
 	DrawString(90, yy, buffer);
 	yy += infosFont->height;
 
-	SetFont(infosFont, entry.is_empty ? LGRAY : BLACK);
+	SetFont(infosFont, entry.is_empty ? LGRAY : DGRAY);
 	snprintf(buffer, sizeof(buffer), "%s", entry.url.c_str());
 	DrawString(90, yy, buffer);
 	yy += infosFont->height;


### PR DESCRIPTION
Before this PR, all 3 lines (title + infos + URL) were displayed in black.
=> Too many things is the most visible color, including data that don't provide the most useful infos to *real users*.

With this, only the title remains in black -- which makes sense as it's the most useful data (and the only one *real users* care about).