### PR TITLE
Save mode and page and restore them when starting app

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -2,6 +2,21 @@
 #include "log.h"
 
 
+#include <string>
+#include <sstream>
+
+namespace patch
+{
+    template < typename T > std::string to_string( const T& n )
+    {
+        std::ostringstream stm ;
+        stm << n ;
+        return stm.str() ;
+    }
+}
+
+
+
 void Application::init()
 {
 	DEBUG("Initializing the application")

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -35,6 +35,8 @@ void Application::init()
 	gui.init();
 
 	curl_global_init(CURL_GLOBAL_ALL);
+
+	restoreModeAndPage();
 }
 
 
@@ -118,10 +120,10 @@ void Application::loadRecentArticles()
 }
 
 
-void Application::setMode(int m)
+void Application::setMode(int m, int forcePageNum)
 {
 	mode = (entries_mode)m;
-	pageNum = 1;
+	pageNum = forcePageNum > 0 ? forcePageNum : 1;
 
 	DEBUG("Switching to mode %d", mode);
 	gui.setMode(mode);
@@ -140,6 +142,8 @@ void Application::show()
 
 	DEBUG("Showing entries: page:%d/%d (total:%d)", pageNum, numberOfPages, countEntries);
 	gui.show(pageNum, numberOfPages, countEntries, entries);
+
+	saveModeAndPage();
 }
 
 
@@ -471,5 +475,26 @@ void Application::deleteAllLocalData()
 	}
 
 	app.show();
+}
+
+
+void Application::restoreModeAndPage()
+{
+	Internal valPageNum = db.selectInternal("gui.pageNum");
+	Internal valMode = db.selectInternal("gui.mode");
+	if (!valPageNum.isNull && !valMode.isNull) {
+		int _pageNum = strtol(valPageNum.value.c_str(), 0, 10);
+		int _mode = strtol(valMode.value.c_str(), 0, 10);
+		if (_pageNum != 0 && _mode != 0) {
+			setMode(_mode, _pageNum);
+		}
+	}
+}
+
+
+void Application::saveModeAndPage()
+{
+	getDb().saveInternal("gui.pageNum", patch::to_string(pageNum));
+	getDb().saveInternal("gui.mode", patch::to_string(mode));
 }
 

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -116,6 +116,9 @@ void Application::loadRecentArticles()
 
 	INFO("End of synchronization process");
 
+	// Syncing changes the number of entries (it can add or remove entries in each mode) => go back to page one
+	pageNum = 1;
+
 	show();
 }
 

--- a/src/application.h
+++ b/src/application.h
@@ -62,7 +62,7 @@ public:
 
 	void handleActionOnReadEntry(int entryId);
 
-	void setMode(int m);
+	void setMode(int m, int forcePageNum = -1);
 
 	Gui &getGui() {
 		return gui;
@@ -94,6 +94,8 @@ private:
 	int countEntriesForCurrentMode();
 	void listEntriesForCurrentMode(std::vector<Entry> &entries);
 
+	void saveModeAndPage();
+	void restoreModeAndPage();
 };
 
 


### PR DESCRIPTION
On this PR, three things:

 * When navigating in pages / modes, save the current page + mode (unread / archived / starred)
 * When starting the application, restore the current page + mode => the user is back where she left (either because she left the app, or because the device turned of causing the app to die)
 * When syncing, we force-go-back to page 1, as number of entries in the current mode might have changed

fix #34