### PR TITLE
Translation : french

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ CFLAGS = -g -gdwarf-3 -std=gnu++11 -Wall -Wextra -Wvla -Wmissing-field-initializ
 all: "Plop! reader.app"
 
 
-src/api/wallabag_api.o: src/main.h src/api/wallabag_api.h src/api/wallabag_api.cpp
+src/api/wallabag_api.o: src/main.h src/translate.h src/api/wallabag_api.h src/api/wallabag_api.cpp
 	$(CC) -c src/api/wallabag_api.cpp $(CFLAGS) -o src/api/wallabag_api.o
 
 src/api/wallabag_config_loader.o: src/main.h src/api/wallabag_config_loader.h src/api/wallabag_config_loader.cpp
@@ -37,7 +37,7 @@ src/gui/gui_button.o: src/main.h src/gui/gui_button.h src/gui/gui_button.cpp
 src/gui/gui_list_item_entry.o: src/main.h src/gui/gui_list_item_entry.h src/gui/gui_list_item_entry.cpp
 	$(CC) -c src/gui/gui_list_item_entry.cpp $(CFLAGS) -o src/gui/gui_list_item_entry.o
 
-src/gui/gui.o: src/main.h src/gui/gui.h src/gui/gui.cpp
+src/gui/gui.o: src/main.h src/translate.h src/gui/gui.h src/gui/gui.cpp
 	$(CC) -c src/gui/gui.cpp $(CFLAGS) -o src/gui/gui.o
 
 src/repositories/entry_repository.o: src/main.h src/repositories/entry_repository.h src/repositories/entry_repository.cpp
@@ -46,7 +46,7 @@ src/repositories/entry_repository.o: src/main.h src/repositories/entry_repositor
 src/repositories/epub_download_queue_repository.o: src/main.h src/repositories/epub_download_queue_repository.h src/repositories/epub_download_queue_repository.cpp
 	$(CC) -c src/repositories/epub_download_queue_repository.cpp $(CFLAGS) -o src/repositories/epub_download_queue_repository.o
 
-src/application.o: src/application.h src/application.cpp
+src/application.o: src/application.h src/translate.h src/application.cpp
 	$(CC) -c src/application.cpp $(CFLAGS) -o src/application.o
 
 src/main.o: src/main.h src/main.cpp

--- a/files/config-dist.json
+++ b/files/config-dist.json
@@ -6,5 +6,6 @@
     "secret_key": "",
     "login": "",
     "password": "",
-    "force_download_epub": false
+    "force_download_epub": false,
+    "lang": "fr"
 }

--- a/src/api/wallabag_api.cpp
+++ b/src/api/wallabag_api.cpp
@@ -39,11 +39,11 @@ void WallabagApi::createOAuthToken(gui_update_progressbar progressbarUpdater)
 	};
 
 	auto beforeRequest = [progressbarUpdater] (void) -> void {
-		progressbarUpdater("Creating OAuth token", Gui::SYNC_PROGRESS_PERCENTAGE_OAUTH_START, NULL);
+		progressbarUpdater(LBL_SYNC_OAUTH_CREATE_TOKEN, Gui::SYNC_PROGRESS_PERCENTAGE_OAUTH_START, NULL);
 	};
 
 	auto afterRequest = [progressbarUpdater] (void) -> void {
-		progressbarUpdater("Creating OAuth token", Gui::SYNC_PROGRESS_PERCENTAGE_OAUTH_END, NULL);
+		progressbarUpdater(LBL_SYNC_OAUTH_CREATE_TOKEN, Gui::SYNC_PROGRESS_PERCENTAGE_OAUTH_END, NULL);
 	};
 
 	auto onSuccess = [this] (CURLcode res, char *json_string) -> void {
@@ -51,7 +51,7 @@ void WallabagApi::createOAuthToken(gui_update_progressbar progressbarUpdater)
 		json_object *json_token = json_tokener_parse_verbose(json_string, &error);
 		if (json_token == NULL) {
 			ERROR("Could not create OAuth token: server returned an invalid JSON string: %s", json_tokener_error_desc(error));
-			throw SyncOAuthException(std::string("Could not create OAuth token: server returned an invalid JSON string: ") + std::string(json_tokener_error_desc(error)));
+			throw SyncOAuthException(std::string(LBL_SYNC_OAUTH_ERROR_CREATE_TOKEN_INVALID_JSON) + std::string(json_tokener_error_desc(error)));
 		}
 
 		const char *access_token = json_object_get_string(json_object_object_get(json_token, "access_token"));
@@ -67,11 +67,11 @@ void WallabagApi::createOAuthToken(gui_update_progressbar progressbarUpdater)
 		ERROR("API: createOAuthToken(): failure. HTTP response code = %ld", response_code);
 
 		std::ostringstream ss;
-		ss << "Could not create OAuth token: server returned a ";
+		ss << LBL_SYNC_OAUTH_ERROR_CREATE_TOKEN_STATUS_CODE;
 		ss << response_code;
-		ss << " status code.";
 		if (response_code == 401) {
-			ss << "\n\nYou should set 'http_login' and 'http_password', or check their value, in the JSON configuration file.";
+			ss << "\n\n";
+			ss << LBL_SYNC_ERROR_HINT_SHOULD_SET_HTTP_BASIC;
 		}
 		throw SyncOAuthException(ss.str());
 	};
@@ -125,11 +125,11 @@ void WallabagApi::refreshOAuthToken(gui_update_progressbar progressbarUpdater)
 	};
 
 	auto beforeRequest = [progressbarUpdater] (void) -> void {
-		progressbarUpdater("Refreshing OAuth token", Gui::SYNC_PROGRESS_PERCENTAGE_OAUTH_START, NULL);
+		progressbarUpdater(LBL_SYNC_OUATH_REFRESH_TOKEN, Gui::SYNC_PROGRESS_PERCENTAGE_OAUTH_START, NULL);
 	};
 
 	auto afterRequest = [progressbarUpdater] (void) -> void {
-		progressbarUpdater("Refreshing OAuth token", Gui::SYNC_PROGRESS_PERCENTAGE_OAUTH_END, NULL);
+		progressbarUpdater(LBL_SYNC_OUATH_REFRESH_TOKEN, Gui::SYNC_PROGRESS_PERCENTAGE_OAUTH_END, NULL);
 	};
 
 	auto onSuccess = [this] (CURLcode res, char *json_string) -> void {
@@ -137,7 +137,7 @@ void WallabagApi::refreshOAuthToken(gui_update_progressbar progressbarUpdater)
 		json_object *json_token = json_tokener_parse_verbose(json_string, &error);
 		if (json_token == NULL) {
 			ERROR("Could not refresh OAuth token: server returned an invalid JSON string: %s", json_tokener_error_desc(error));
-			throw SyncOAuthException(std::string("Could not refresh OAuth token: server returned an invalid JSON string: ") + std::string(json_tokener_error_desc(error)));
+			throw SyncOAuthException(std::string(LBL_SYNC_OAUTH_ERROR_REFRESH_TOKEN_INVALID_JSON) + std::string(json_tokener_error_desc(error)));
 		}
 
 		const char *access_token = json_object_get_string(json_object_object_get(json_token, "access_token"));
@@ -153,11 +153,11 @@ void WallabagApi::refreshOAuthToken(gui_update_progressbar progressbarUpdater)
 		ERROR("API: refreshOAuthToken(): failure. HTTP response code = %ld", response_code);
 
 		std::ostringstream ss;
-		ss << "Could not refresh OAuth token: server returned a ";
+		ss << LBL_SYNC_OAUTH_ERROR_REFRESH_TOKEN_STATUS_CODE;
 		ss << response_code;
-		ss << " status code.";
 		if (response_code == 401) {
-			ss << "\n\nYou should set 'http_login' and 'http_password', or check their value, in the JSON configuration file.";
+			ss << "\n\n";
+			ss << LBL_SYNC_ERROR_HINT_SHOULD_SET_HTTP_BASIC;
 		}
 		throw SyncOAuthException(ss.str());
 	};
@@ -223,22 +223,22 @@ void WallabagApi::loadRecentArticles(EntryRepository repository, EpubDownloadQue
 	};
 
 	auto beforeRequest = [progressbarUpdater] (void) -> void {
-		progressbarUpdater("Fetching entries: HTTP request", Gui::SYNC_PROGRESS_PERCENTAGE_DOWN_HTTP_START, NULL);
+		progressbarUpdater(LBL_SYNC_FETCH_ENTRIES_HTTP_REQUEST, Gui::SYNC_PROGRESS_PERCENTAGE_DOWN_HTTP_START, NULL);
 	};
 
 	auto afterRequest = [progressbarUpdater] (void) -> void {
-		progressbarUpdater("Fetching entries: HTTP request", Gui::SYNC_PROGRESS_PERCENTAGE_DOWN_HTTP_END, NULL);
+		progressbarUpdater(LBL_SYNC_FETCH_ENTRIES_HTTP_REQUEST, Gui::SYNC_PROGRESS_PERCENTAGE_DOWN_HTTP_END, NULL);
 	};
 
 	auto onSuccess = [&] (CURLcode res, char *json_string) -> void {
 		DEBUG("API: loadRecentArticles(): response fetched from server");
-		progressbarUpdater("Saving entries to local database...", Gui::SYNC_PROGRESS_PERCENTAGE_DOWN_SAVE_START, NULL);
+		progressbarUpdater(LBL_SYNC_SAVE_ENTRIES_TO_LOCAL_DB, Gui::SYNC_PROGRESS_PERCENTAGE_DOWN_SAVE_START, NULL);
 
 		json_tokener_error error;
 		json_object *obj = json_tokener_parse_verbose(json_string, &error);
 		if (obj == NULL) {
 			ERROR("Could not decode entries: server returned an invalid JSON string: %s", json_tokener_error_desc(error));
-			throw SyncInvalidJsonException(std::string("Could not decode entries: server returned an invalid JSON string: ") + std::string(json_tokener_error_desc(error)));
+			throw SyncInvalidJsonException(std::string(LBL_SYNC_ERROR_DECODE_ENTRIES_INVALID_JSON) + std::string(json_tokener_error_desc(error)));
 		}
 
 		array_list *items = json_object_get_array(json_object_object_get(json_object_object_get(obj, "_embedded"), "items"));
@@ -298,22 +298,22 @@ void WallabagApi::loadRecentArticles(EntryRepository repository, EpubDownloadQue
 			if (i >= nextIncrement) {
 				nextIncrement += incrementPercentageEvery;
 				percentage += 1;
-				progressbarUpdater("Saving entries to local database...", percentage, NULL);
+				progressbarUpdater(LBL_SYNC_SAVE_ENTRIES_TO_LOCAL_DB, percentage, NULL);
 			}
 		}
 
-		progressbarUpdater("Saving entries to local database...", Gui::SYNC_PROGRESS_PERCENTAGE_DOWN_SAVE_END, NULL);
+		progressbarUpdater(LBL_SYNC_SAVE_ENTRIES_TO_LOCAL_DB, Gui::SYNC_PROGRESS_PERCENTAGE_DOWN_SAVE_END, NULL);
 	};
 
 	auto onFailure = [this] (CURLcode res, long response_code, CURL *curl) -> void {
 		ERROR("API: loadRecentArticles(): failure. HTTP response code = %ld", response_code);
 
 		std::ostringstream ss;
-		ss << "Could not load entries from server: server returned a ";
+		ss << LBL_SYNC_FETCH_ENTRIES_ERROR_STATUS_CODE;
 		ss << response_code;
-		ss << " status code.";
 		if (response_code == 401) {
-			ss << "\n\nYou should set 'http_login' and 'http_password', or check their value, in the JSON configuration file.";
+			ss << "\n\n";
+			ss << LBL_SYNC_ERROR_HINT_SHOULD_SET_HTTP_BASIC;
 		}
 		throw SyncHttpException(ss.str());
 	};
@@ -378,7 +378,7 @@ static void do_download_epub_from_queue(void *data)
 	float currentIncrement = incrementPerDownload * ((float)count_total_downloads - (float)count_remaining_downloads);
 	float percentage = (float)Gui::SYNC_PROGRESS_PERCENTAGE_DOWN_FILES_START + currentIncrement;
 
-	(*_progressbarUpdater)("Downloading EPUB files...", percentage, NULL);
+	(*_progressbarUpdater)(LBL_SYNC_DOWNLOAD_EPUB_FILES, percentage, NULL);
 	pthread_mutex_unlock(&mutex_download_progress);
 
 	DEBUG("[background] <- Done downloading entry %d on thread %u", entry_id, (int)pthread_self());
@@ -390,7 +390,7 @@ void WallabagApi::startBackgroundDownloads(EntryRepository &repository, EpubDown
 	DEBUG("-> Starting downloading EPUB files in the background");
 
 	int percent = Gui::SYNC_PROGRESS_PERCENTAGE_DOWN_FILES_START;
-	progressbarUpdater("Downloading EPUB files...", percent, NULL);
+	progressbarUpdater(LBL_SYNC_DOWNLOAD_EPUB_FILES, percent, NULL);
 
 	// TODO actually download EPUB files in the background + save them + update the corresponding entries ;-)
 
@@ -441,7 +441,7 @@ void WallabagApi::startBackgroundDownloads(EntryRepository &repository, EpubDown
 	thpool_destroy(thpool);
 
 	percent = Gui::SYNC_PROGRESS_PERCENTAGE_DOWN_FILES_END;
-	progressbarUpdater("Downloading EPUB files: done.", percent, NULL);
+	progressbarUpdater(LBL_SYNC_DOWNLOAD_EPUB_FILES_DONE, percent, NULL);
 
 	pthread_mutex_destroy(&mutex_download_progress);
 
@@ -464,7 +464,7 @@ void WallabagApi::downloadEpub(EntryRepository &repository, Entry &entry, gui_up
 
 	if (percent > -1) {
 		char buffer[1024];
-		snprintf(buffer, sizeof(buffer), "Downloading EPUB for %d/%s...", entry.id, entry.remote_id.c_str());
+		snprintf(buffer, sizeof(buffer), LBL_SYNC_DOWNLOAD_EPUB_FILE_FOR_ENTRY, entry.id, entry.remote_id.c_str());
 		progressbarUpdater(buffer, percent, NULL);
 	}
 
@@ -553,7 +553,7 @@ void WallabagApi::syncEntriesToServer(EntryRepository repository, gui_update_pro
 	// For each entry that's been updated more recently on the device than on the server,
 	// send updates (archived / starred statuses) to the server
 
-	progressbarUpdater("Sending updated statuses to server", Gui::SYNC_PROGRESS_PERCENTAGE_UP_START, NULL);
+	progressbarUpdater(LBL_SYNC_SEND_UPDATES_TO_SERVER, Gui::SYNC_PROGRESS_PERCENTAGE_UP_START, NULL);
 
 
 	std::vector<Entry> changedEntries;
@@ -581,11 +581,11 @@ void WallabagApi::syncEntriesToServer(EntryRepository repository, gui_update_pro
 		if (i >= nextIncrement) {
 			nextIncrement += incrementPercentageEvery;
 			percentage += 1;
-			progressbarUpdater("Sending updated statuses to server", percentage, NULL);
+			progressbarUpdater(LBL_SYNC_SEND_UPDATES_TO_SERVER, percentage, NULL);
 		}
 	}
 
-	progressbarUpdater("Sending updated statuses to server", Gui::SYNC_PROGRESS_PERCENTAGE_UP_END, NULL);
+	progressbarUpdater(LBL_SYNC_SEND_UPDATES_TO_SERVER, Gui::SYNC_PROGRESS_PERCENTAGE_UP_END, NULL);
 
 	DEBUG("API: syncEntriesToServer(): done");
 }
@@ -650,11 +650,11 @@ void WallabagApi::syncOneEntryToServer(EntryRepository repository, Entry &entry)
 		ERROR("API: syncOneEntryToServer(): failure. HTTP response code = %ld", response_code);
 
 		std::ostringstream ss;
-		ss << "Could not sync entry to server: server returned a ";
+		ss << LBL_SYNC_SEND_UPDATES_TO_SERVER_ERROR_STATUS_CODE;
 		ss << response_code;
-		ss << " status code.";
 		if (response_code == 401) {
-			ss << "\n\nYou should set 'http_login' and 'http_password', or check their value, in the JSON configuration file.";
+			ss << "\n\n";
+			ss << LBL_SYNC_ERROR_HINT_SHOULD_SET_HTTP_BASIC;
 		}
 		throw SyncHttpException(ss.str());
 	};
@@ -690,11 +690,11 @@ void WallabagApi::fetchServerVersion(gui_update_progressbar progressbarUpdater)
 	};
 
 	auto beforeRequest = [progressbarUpdater] (void) -> void {
-		progressbarUpdater("Fetching server version", Gui::SYNC_PROGRESS_PERCENTAGE_FETCH_SERVER_VERSION_START, NULL);
+		progressbarUpdater(LBL_SYNC_FETCH_SERVER_VERSION, Gui::SYNC_PROGRESS_PERCENTAGE_FETCH_SERVER_VERSION_START, NULL);
 	};
 
 	auto afterRequest = [progressbarUpdater] (void) -> void {
-		progressbarUpdater("Fetching server version", Gui::SYNC_PROGRESS_PERCENTAGE_FETCH_SERVER_VERSION_END, NULL);
+		progressbarUpdater(LBL_SYNC_FETCH_SERVER_VERSION, Gui::SYNC_PROGRESS_PERCENTAGE_FETCH_SERVER_VERSION_END, NULL);
 	};
 
 	auto onSuccess = [&] (CURLcode res, char *json_string) -> void {
@@ -715,11 +715,11 @@ void WallabagApi::fetchServerVersion(gui_update_progressbar progressbarUpdater)
 		ERROR("API: fetchServerVersion(): failure. HTTP response code = %ld", response_code);
 
 		std::ostringstream ss;
-		ss << "Could not load entries from server: server returned a ";
+		ss << LBL_SYNC_FETCH_SERVER_VERSION_ERROR_STATUS_CODE;
 		ss << response_code;
-		ss << " status code.";
 		if (response_code == 401) {
-			ss << "\n\nYou should set 'http_login' and 'http_password', or check their value, in the JSON configuration file.";
+			ss << "\n\n";
+			ss << LBL_SYNC_ERROR_HINT_SHOULD_SET_HTTP_BASIC;
 		}
 		throw SyncHttpException(ss.str());
 	};

--- a/src/api/wallabag_api.h
+++ b/src/api/wallabag_api.h
@@ -15,6 +15,7 @@
 
 #include "../log.h"
 #include "../exceptions.h"
+#include "../translate.h"
 #include "../gui/gui.h"
 
 #include "../libs/thpool/thpool.h"

--- a/src/api/wallabag_config_loader.cpp
+++ b/src/api/wallabag_config_loader.cpp
@@ -110,6 +110,12 @@ WallabagConfig WallabagConfigLoader::load(void)
 
 	config.force_download_epub = json_object_get_boolean(json_object_object_get(obj, "force_download_epub"));
 
+	// TODO the language config should not be in "wallabag config" (but, for now, the config.json file is parsed here... )
+	const char *lang = json_object_get_string(json_object_object_get(obj, "lang"));
+	if (lang && strcmp(lang, "fr") == 0) {
+		global_lang = LANG_FR;
+	}
+
 	if (
 		(url == NULL || strlen(url) == 0)
 		|| (client_id == NULL || strlen(client_id) == 0)

--- a/src/api/wallabag_config_loader.h
+++ b/src/api/wallabag_config_loader.h
@@ -9,6 +9,8 @@
 #include "../log.h"
 #include "../exceptions.h"
 
+#include "../translate.h"
+
 class WallabagConfigLoader
 {
 public:

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -86,8 +86,8 @@ void Application::loadRecentArticles()
 		return;
 	}
 
-	gui.openProgressBar(ICON_WIFI, "Synchronizing with server", "Starting synchronization", 0, [](int button) {});
-	gui.updateProgressBar("Fetching recent entries from server", Gui::SYNC_PROGRESS_PERCENTAGE_ALL_START);
+	gui.openProgressBar(ICON_WIFI, LBL_SYNC_DIALOG_TITLE, LBL_SYNC_START_SYNC, 0, [](int button) {});
+	gui.updateProgressBar(LBL_SYNC_FETCHING_RECENT_ENTRIES, Gui::SYNC_PROGRESS_PERCENTAGE_ALL_START);
 
 	Internal lastSyncTimestampObj = db.selectInternal("sync.last-sync.timestamp");
 	time_t lastSyncTimestamp = lastSyncTimestampObj.isNull ? 0 : atoi(lastSyncTimestampObj.value.c_str());
@@ -106,11 +106,11 @@ void Application::loadRecentArticles()
 			app.gui.updateProgressBar(text, percent);
 		});
 
-		gui.updateProgressBar("All done \\o/", Gui::SYNC_PROGRESS_PERCENTAGE_ALL_DONE);
+		gui.updateProgressBar(LBL_SYNC_SUCCESS_DONE, Gui::SYNC_PROGRESS_PERCENTAGE_ALL_DONE);
 	}
 	catch (SyncAbortAllOperations &e) {
 		ERROR("Synchronization Exception: %s => aborting sync!", e.what());
-		DialogSynchro(ICON_ERROR, PLOP_APPLICATION_FULLNAME, e.what(), "Too bad ;-(", NULL, NULL);
+		DialogSynchro(ICON_ERROR, PLOP_APPLICATION_FULLNAME, e.what(), LBL_SYNC_FAILED_TOO_BAD, NULL, NULL);
 	}
 	gui.closeProgressBar();
 

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -292,7 +292,7 @@ void Application::handleActionOnReadEntry(int entryId)
 	Entry entry = entryRepository.get(entryId);
 
 	char buffer[2048];
-	snprintf(buffer, sizeof(buffer), "What do you want to do with entry #%d?\n%.128s?", entry.id, entry.title.c_str());
+	snprintf(buffer, sizeof(buffer), LBL_AFTERREAD_ACTIONONENTRY_WHAT_TO_DO_WITH_ENTRY_CONTENT, entry.id, entry.title.c_str());
 
 	bool isArchived = entry.local_is_archived;
 	bool isStarred = entry.local_is_starred;
@@ -300,30 +300,30 @@ void Application::handleActionOnReadEntry(int entryId)
 	const char *strButton1, *strButton2;
 
 	if (isArchived == false) {
-		strButton1 = "Archive";
+		strButton1 = LBL_AFTERREAD_ACTIONONENTRY_BUTTON_ARCHIVE;
 		if (isStarred == false) {
-			strButton2 = "Archive + Star";
+			strButton2 = LBL_AFTERREAD_ACTIONONENTRY_BUTTON_ARCHIVE_STAR;
 		}
 		else {
-			strButton2 = "Archive + Un-star";
+			strButton2 = LBL_AFTERREAD_ACTIONONENTRY_BUTTON_ARCHIVE_UNSTAR;
 		}
 	}
 	else {
-		strButton1 = "Un-archive";
+		strButton1 = LBL_AFTERREAD_ACTIONONENTRY_BUTTON_UNARCHIVE;
 		if (isStarred == false) {
-			strButton2 = "Un-archive + Star";
+			strButton2 = LBL_AFTERREAD_ACTIONONENTRY_BUTTON_UNARCHIVE_STAR;
 		}
 		else {
-			strButton2 = "Un-archive + Un-star";
+			strButton2 = LBL_AFTERREAD_ACTIONONENTRY_BUTTON_UNARCHIVE_UNSTAR;
 		}
 	}
 
-	int result = DialogSynchro(ICON_QUESTION, "What now with this entry?", buffer, strButton1, strButton2, "Do nothing");
+	int result = DialogSynchro(ICON_QUESTION, LBL_AFTERREAD_ACTIONONENTRY_WHAT_TO_DO_WITH_ENTRY_TITLE, buffer, strButton1, strButton2, LBL_AFTERREAD_ACTIONONENTRY_BUTTON_DONOTHING);
 
 	if (result == 3) {
 		// do nothing
 		show();
-		gui.statusBarText("Thanks! You can read another entry, now ;-)");
+		gui.statusBarText(LBL_STATUSBAR_AFTERREAD_THANKS_READ_ANOTHER);
 		return;
 	}
 
@@ -366,14 +366,14 @@ void Application::handleActionOnReadEntry(int entryId)
 	// One entry has changed => we must redraw the list
 	show();
 
-	gui.statusBarText("This change will be sent to the server next time you synchronize.");
+	gui.statusBarText(LBL_STATUSBAR_AFTERREAD_CHANGE_SENT_ON_NEXT_SYNC);
 }
 
 
 void Application::foreground()
 {
 	if (isLastActionRead && lastReadEntryId != 0) {
-		gui.statusBarText("Choose what to do with the entry you've just read...");
+		gui.statusBarText(LBL_STATUSBAR_AFTERREAD_WHAT_TO_DO_WITH_ENTRY);
 		handleActionOnReadEntry(lastReadEntryId);
 	}
 	isLastActionRead = false;

--- a/src/application.h
+++ b/src/application.h
@@ -12,6 +12,8 @@
 
 #include "gui/gui.h"
 
+#include "translate.h"
+
 #include "repositories/entry_repository.h"
 #include "repositories/epub_download_queue_repository.h"
 

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -323,17 +323,17 @@ void Gui::displayMainMenu()
 void Gui::touchEndEvent(int x, int y)
 {
 	if (exitButton.hit(x, y)) {
-		statusBarText("Closing the application. Bye, see you soon ;-)");
+		statusBarText(LBL_STATUSBAR_CLOSING_APPLICATION_BYE);
 
 		CloseApp();
 	}
 	else if (syncButton.hit(x, y)) {
-		statusBarText("Launching synchronization with server...");
+		statusBarText(LBL_STATUSBAR_LAUNCHING_SYNC);
 
 		app.loadRecentArticles();
 	}
 	else if (menuButton.hit(x, y)) {
-		statusBarText("Opening the application's main menu...");
+		statusBarText(LBL_STATUSBAR_OPENING_MAIN_MENU);
 
 		displayMainMenu();
 	}
@@ -344,7 +344,7 @@ void Gui::touchEndEvent(int x, int y)
 				if (item.hasEntry()) {
 					item.draw(false, true, true);
 
-					statusBarText("Loading reader app for entry#%d - %s...", item.getEntry().id, item.getEntry().title.c_str());
+					statusBarText(LBL_STATUSBAR_LOADING_READER_FOR_ENTRY, item.getEntry().id, item.getEntry().title.c_str());
 
 					app.read(item.getEntry());
 				}

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -105,13 +105,13 @@ void Gui::show(int numPage, int numberOfPages, int countAllEntries, std::vector<
 	SetFont(smallTitleFont, BLACK);
 
 	if (mode == 1) {
-		snprintf(buffer, sizeof(buffer), PLOP_APPLICATION_SHORTNAME " - unread entries");
+		snprintf(buffer, sizeof(buffer), PLOP_APPLICATION_SHORTNAME " - %s", LBL_HEADER_UNREAD_ENTRIES);
 	}
 	else if (mode == 2) {
-		snprintf(buffer, sizeof(buffer), PLOP_APPLICATION_SHORTNAME " - archived entries");
+		snprintf(buffer, sizeof(buffer), PLOP_APPLICATION_SHORTNAME " - %s", LBL_HEADER_ARCHIVED_ENTRIES);
 	}
 	else if (mode == 3) {
-		snprintf(buffer, sizeof(buffer), PLOP_APPLICATION_SHORTNAME " - starred entries");
+		snprintf(buffer, sizeof(buffer), PLOP_APPLICATION_SHORTNAME " - %s", LBL_HEADER_STARRED_ENTRIES);
 	}
 	else {
 		snprintf(buffer, sizeof(buffer), PLOP_APPLICATION_SHORTNAME);
@@ -119,7 +119,7 @@ void Gui::show(int numPage, int numberOfPages, int countAllEntries, std::vector<
 	DrawString(90, y, buffer);
 	y += 35;
 
-	snprintf(buffer, sizeof(buffer), "Page %d / %d (%d entries)", numPage, numberOfPages, countAllEntries);
+	snprintf(buffer, sizeof(buffer), LBL_HEADER_PAGE_NUM, numPage, numberOfPages, countAllEntries);
 	DrawString(90, y, buffer);
 	y += 35;
 
@@ -170,17 +170,17 @@ void Gui::show(int numPage, int numberOfPages, int countAllEntries, std::vector<
 
 	if (countAllEntries == 0) {
 		if (mode == 1) {
-			statusBarText("You don't have any unread entries. Use [SYNC] to fetch some from the server.");
+			statusBarText(LBL_STATUSBAR_NO_UNREAD_ENTRIES_USE_SYNC);
 		}
 		else if (mode == 2) {
-			statusBarText("You don't have any archived entries. Use [MENU] to view unread entries.");
+			statusBarText(LBL_STATUSBAR_NO_ARCHIVED_ENTRIES_USE_MENU);
 		}
 		else if (mode == 3) {
-			statusBarText("You don't have any starred entries. Use [MENU] to view unread entries.");
+			statusBarText(LBL_STATUSBAR_NO_STARRED_ENTRIES_USE_MENU);
 		}
 	}
 	else {
-		statusBarText("Use [<] and [>] keys to navigate. Touch an entry to read it.");
+		statusBarText(LBL_STATUSBAR_USE_KEYS_OR_TOUCH);
 	}
 
 	//FullUpdateHQ();

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -273,17 +273,25 @@ void Gui::displayMainMenu()
 			const char *text = PLOP_APPLICATION_FULLNAME " " PLOP_VERSION_STR "\n"
 					PLOP_WEBSITE_URL "\n"
 					"\n"
-					"A Wallabag application for Pocketbook Touch Lux ereaders." "\n"
+					"%1$s\n"
 					"\n"
-					"Developed by Pascal MARTIN.\n"
+					"%2$s\n"
 					"@pascal_martin\n"
 					"https://blog.pascal-martin.fr\n"
 					"\n"
-					"Contribute (GPL-3.0):" "\n"
+					"%3$s\n"
 					PLOP_OPENSOURCE_URL;
-			DialogSynchro(ICON_INFORMATION, PLOP_APPLICATION_FULLNAME, text, "OK", NULL, NULL);
 
-			app.getGui().statusBarText("Feel free to contribute on %s ;-)", PLOP_OPENSOURCE_URL);
+			char buffer[2048];
+			snprintf(buffer, sizeof(buffer), text,
+				LBL_ABOUT_MAIN_DESCRIPTION,
+				LBL_ABOUT_DEVELOPED_BY_PM,
+				LBL_ABOUT_CONTRIBUTE
+			);
+
+			DialogSynchro(ICON_INFORMATION, PLOP_APPLICATION_FULLNAME, buffer, "OK", NULL, NULL);
+
+			app.getGui().statusBarText(LBL_STATUSBAR_FEEL_FREE_TO_CONTRIBUTE, PLOP_OPENSOURCE_URL);
 
 			DEBUG("Opening About dialog - closed");
 		}

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -296,16 +296,16 @@ void Gui::displayMainMenu()
 			DEBUG("Opening About dialog - closed");
 		}
 		else if (index == 5) {
-			int result = DialogSynchro(ICON_QUESTION, "Delete all local data?", "Do you really want to delete all local data?\nYou will need to sync from server to fetch new data.\nData updated locally and not already synced to server will be lost.", "Delete local data", "Cancel", NULL);
+			int result = DialogSynchro(ICON_QUESTION, LBL_DELETEALL_DIALOG_TITLE, LBL_DELETEALL_DIALOG_CONTENT, LBL_DELETEALL_DIALOG_BTN_OK, LBL_DELETEALL_DIALOG_BTN_CANCEL, NULL);
 			if (result == 1) {
 				DEBUG("Deleting all local data...");
 				app.deleteAllLocalData();
 				DEBUG("Deleting all local data: done");
 
-				app.getGui().statusBarText("Local data deleted. You should now run a sync to fetch data from server ;-)");
+				app.getGui().statusBarText(LBL_STATUSBAR_DELETEALL_DONE);
 			}
 			else if (result == 2) {
-				app.getGui().statusBarText("Local data has been left untouched.");
+				app.getGui().statusBarText(LBL_STATUSBAR_DELETEALL_CANCELED);
 			}
 		}
 	};

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -302,7 +302,7 @@ void Gui::displayMainMenu()
 		}
 	};
 
-	statusBarText("Choose an action in the menu, or close it...");
+	statusBarText(LBL_STATUSBAR_MAINMENU);
 
 	SetMenuFont(entryTitleFont);
 	irect rect = GetMenuRect(menu);

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -217,11 +217,11 @@ void Gui::displayMainMenu()
 	DEBUG("Opening main menu");
 
 	const char *str0 = PLOP_APPLICATION_FULLNAME;
-	const char *str1 = "Display unread entries";
-	const char *str2 = "Display archived entries";
-	const char *str3 = "Display starred entries";
-	const char *str_reset = "Delete all local data";
-	const char *str4 = "About";
+	const char *str1 = LBL_MAINMENU_MODE_UNREAD_ENTRIES;
+	const char *str2 = LBL_MAINMENU_MODE_ARCHIVED_ENTRIES;
+	const char *str3 = LBL_MAINMENU_MODE_STARRED_ENTRIES;
+	const char *str_reset = LBL_MAINMENU_DELETE_ALL_LOCAL_DATA;
+	const char *str4 = LBL_MAINMENU_ABOUT;
 
 	menu = (imenu *)calloc(7, sizeof(imenu));
 

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -370,7 +370,7 @@ void Gui::touchLong(int x, int y)
 			if (item.hasEntry()) {
 				item.draw(false, true, true);
 
-				statusBarText("Opening context menu for entry#%d - %s...", item.getEntry().id, item.getEntry().title.c_str());
+				statusBarText(LBL_STATUSBAR_OPENING_CONTEXTMENU_FOR_ENTRY, item.getEntry().id, item.getEntry().title.c_str());
 
 				displayContextMenuOnEntry(item, x, y);
 			}

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -388,11 +388,11 @@ static void contextEntryOnMenuHandler(int index)
 	CloseContextMenu(contextMenu);
 
 	if (index == 1) {
-		app.getGui().statusBarText("Loading reader app for entry#%d (HTML) - %s...", contextMenuEntry.id, contextMenuEntry.title.c_str());
+		app.getGui().statusBarText(LBL_STATUSBAR_OPENING_READERAPP_FOR_ENTRY_FORMAT, contextMenuEntry.id, contextMenuEntry.title.c_str(), "HTML");
 		app.read(contextMenuEntry, Application::FORMAT_HTML);
 	}
 	else if (index == 2) {
-		app.getGui().statusBarText("Loading reader app for entry#%d (EPUB) - %s...", contextMenuEntry.id, contextMenuEntry.title.c_str());
+		app.getGui().statusBarText(LBL_STATUSBAR_OPENING_READERAPP_FOR_ENTRY_FORMAT, contextMenuEntry.id, contextMenuEntry.title.c_str(), "EPUB");
 		app.read(contextMenuEntry, Application::FORMAT_EPUB);
 	}
 
@@ -412,8 +412,8 @@ void Gui::displayContextMenuOnEntry(GuiListItemEntry &item, int xTouch, int yTou
 	contextMenu = CreateContextMenu(id);
 
 	const char *str0 = entry.title.c_str();
-	const char *str1 = "Read HTML content";
-	const char *str2 = "Read EPUB version";
+	const char *str1 = LBL_ENTRY_CONTEXTMENU_READ_HTML;
+	const char *str2 = LBL_ENTRY_CONTEXTMENU_READ_EPUB;
 
 	menu = (imenu *)calloc(4, sizeof(imenu));
 

--- a/src/gui/gui.h
+++ b/src/gui/gui.h
@@ -13,6 +13,7 @@
 #include "gui_button.h"
 #include "gui_list_item_entry.h"
 
+#include "../translate.h"
 
 class Application;
 extern Application app;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,8 @@
 #include "main.h"
-
+#include "translate.h"
 
 Application app;
+int global_lang = LANG_EN;
 
 
 static int main_handler(int event_type, int param_one, int param_two)

--- a/src/translate.h
+++ b/src/translate.h
@@ -228,4 +228,94 @@ extern int global_lang;
 	: "Choose what to do with the entry you've just read..." \
 )
 
+#define LBL_SYNC_OAUTH_CREATE_TOKEN (IS_LANG_FR \
+	? "Création d'un jeton OAuth" \
+	: "Creating OAuth token" \
+)
+
+#define LBL_SYNC_OAUTH_ERROR_CREATE_TOKEN_INVALID_JSON (IS_LANG_FR \
+	? "Échec création jeton OAuth : le serveur a retourné une chaine JSON invalide : " \
+	: "Could not create OAuth token: server returned an invalid JSON string: " \
+)
+
+#define LBL_SYNC_OAUTH_ERROR_CREATE_TOKEN_STATUS_CODE (IS_LANG_FR \
+	? "Échec création jeton OAuth : le serveur a retourné un code statut : " \
+	: "Could not create OAuth token: server returned status code: " \
+)
+
+#define LBL_SYNC_ERROR_HINT_SHOULD_SET_HTTP_BASIC (IS_LANG_FR \
+	? "Vous devriez renseigner 'http_login' et 'http_password', ou vérifier leurs valeurs, dans le fichier ce configuration JSON." \
+	: "You should set 'http_login' and 'http_password', or check their value, in the JSON configuration file." \
+)
+
+#define LBL_SYNC_OUATH_REFRESH_TOKEN (IS_LANG_FR \
+	? "Rafraichissement du jeton OAuth" \
+	: "Refreshing OAuth token" \
+)
+
+#define LBL_SYNC_OAUTH_ERROR_REFRESH_TOKEN_INVALID_JSON (IS_LANG_FR \
+	? "Échec rafraichissement jeton OAuth : le serveur a retourné une chaine JSON invalide : " \
+	: "Could not refresh OAuth token: server returned an invalid JSON string: " \
+)
+
+#define LBL_SYNC_OAUTH_ERROR_REFRESH_TOKEN_STATUS_CODE (IS_LANG_FR \
+	? "Échec rafraichissement jeton OAuth : le serveur a retourné un code statut : " \
+	: "Could not refresh OAuth token: server returned status code: " \
+)
+
+#define LBL_SYNC_FETCH_ENTRIES_HTTP_REQUEST (IS_LANG_FR \
+	? "Téléchargement des entrées : requête HTTP" \
+	: "Fetching entries: HTTP request" \
+)
+
+#define LBL_SYNC_SAVE_ENTRIES_TO_LOCAL_DB (IS_LANG_FR \
+	? "Enregistrement des entrées en base de données locale..." \
+	: "Saving entries to local database..." \
+)
+
+#define LBL_SYNC_ERROR_DECODE_ENTRIES_INVALID_JSON (IS_LANG_FR \
+	? "Échec décodage des entrées : le serveur a retourné une chaine JSON invalide : " \
+	: "Could not decode entries: server returned an invalid JSON string: " \
+)
+
+#define LBL_SYNC_FETCH_ENTRIES_ERROR_STATUS_CODE (IS_LANG_FR \
+	? "Échec du téléchargement des entrées : le serveur a retourné un code statut : " \
+	: "Could not load entries from server: server returned status code: " \
+)
+
+#define LBL_SYNC_DOWNLOAD_EPUB_FILES (IS_LANG_FR \
+	? "Téléchargement des fichiers EPUB..." \
+	: "Downloading EPUB files..." \
+)
+
+#define LBL_SYNC_DOWNLOAD_EPUB_FILES_DONE (IS_LANG_FR \
+	? "Téléchargement des fichiers EPUB : terminé \\o/." \
+	: "Downloading EPUB files: done \\o/." \
+)
+
+#define LBL_SYNC_DOWNLOAD_EPUB_FILE_FOR_ENTRY (IS_LANG_FR \
+	? "Téléchargement de l'EPUB pour %1$d/%2$s..." \
+	: "Downloading EPUB for %1$d/%2$s..." \
+)
+
+#define LBL_SYNC_SEND_UPDATES_TO_SERVER (IS_LANG_FR \
+	? "Envoi des mises à jour au serveur..." \
+	: "Sending updated statuses to server" \
+)
+
+#define LBL_SYNC_SEND_UPDATES_TO_SERVER_ERROR_STATUS_CODE (IS_LANG_FR \
+	? "Échec envoi mises à jour : le serveur a retourné un code statut : " \
+	: "Could not sync entry to server: server returned status code: " \
+)
+
+#define LBL_SYNC_FETCH_SERVER_VERSION (IS_LANG_FR \
+	? "Obtention de la version du serveur..." \
+	: "Fetching server version" \
+)
+
+#define LBL_SYNC_FETCH_SERVER_VERSION_ERROR_STATUS_CODE (IS_LANG_FR \
+	? "Échec obtention version serveur : le serveur a retourné un code statut : " \
+	: "Could not load entries from server: server returned status code: " \
+)
+
 #endif /* SRC_TRANSLATE_H_ */

--- a/src/translate.h
+++ b/src/translate.h
@@ -1,0 +1,46 @@
+#ifndef SRC_TRANSLATE_H_
+#define SRC_TRANSLATE_H_
+
+#define IS_LANG_FR (true)
+
+#define LBL_HEADER_UNREAD_ENTRIES (IS_LANG_FR \
+	? "entrées non lues" \
+	: "unread entries" \
+)
+
+#define LBL_HEADER_ARCHIVED_ENTRIES (IS_LANG_FR \
+	? "entrées archivées" \
+	: "archives entries" \
+)
+
+#define LBL_HEADER_STARRED_ENTRIES (IS_LANG_FR \
+	? "entrées étoilées" \
+	: "starred entries" \
+)
+
+#define LBL_HEADER_PAGE_NUM (IS_LANG_FR \
+	? "Page %1$d / %2$d (%3$d entrées)" \
+	: "Page %1$d / %2$d (%3$d entries)" \
+)
+
+#define LBL_STATUSBAR_NO_UNREAD_ENTRIES_USE_SYNC (IS_LANG_FR \
+	? "Vous n'avez aucune entrée non lue. Utilisez [SYNC] pour en obtenir depuis le serveur." \
+	: "You don't have any unread entries. Use [SYNC] to fetch some from the server." \
+)
+
+#define LBL_STATUSBAR_NO_ARCHIVED_ENTRIES_USE_MENU (IS_LANG_FR \
+	? "Vous n'avez aucune entrée archivée. Utilisez [MENU] pour voir les entrées non lues." \
+	: "You don't have any archived entries. Use [MENU] to view unread entries." \
+)
+
+#define LBL_STATUSBAR_NO_STARRED_ENTRIES_USE_MENU (IS_LANG_FR \
+	? "Vous n'avez aucune entrée étoilée. Utilisez [MENU] pour voir les entrées non lues." \
+	: "You don't have any starred entries. Use [MENU] to view unread entries." \
+)
+
+#define LBL_STATUSBAR_USE_KEYS_OR_TOUCH (IS_LANG_FR \
+	? "Utilisez les touches [<] et [>] pour naviguer. Touchez une entrée pour la lire." \
+	: "Use [<] and [>] keys to navigate. Touch an entry to read it." \
+)
+
+#endif /* SRC_TRANSLATE_H_ */

--- a/src/translate.h
+++ b/src/translate.h
@@ -68,4 +68,9 @@
 	: "About" \
 )
 
+#define LBL_STATUSBAR_MAINMENU (IS_LANG_FR \
+	? "Choisissez une action dans le menu, ou fermez-le..." \
+	: "Choose an action in the menu, or close it..." \
+)
+
 #endif /* SRC_TRANSLATE_H_ */

--- a/src/translate.h
+++ b/src/translate.h
@@ -123,4 +123,24 @@
 	: "Local data has been left untouched." \
 )
 
+#define LBL_STATUSBAR_CLOSING_APPLICATION_BYE (IS_LANG_FR \
+	? "Fermeture de l'application. À bientôt ;-)" \
+	: "Closing the application. Bye, see you soon ;-)" \
+)
+
+#define LBL_STATUSBAR_LAUNCHING_SYNC (IS_LANG_FR \
+	? "Lancement de la synchronisation avec le serveur..." \
+	: "Launching synchronization with server..." \
+)
+
+#define LBL_STATUSBAR_OPENING_MAIN_MENU (IS_LANG_FR \
+	? "Ouverture du menu principal de l'application..." \
+	: "Opening the application's main menu..." \
+)
+
+#define LBL_STATUSBAR_LOADING_READER_FOR_ENTRY (IS_LANG_FR \
+	? "Chargement de l'appli de lecture pour #%1$d - %2$s..." \
+	: "Loading reader app for entry#%1$d - %2$s..." \
+)
+
 #endif /* SRC_TRANSLATE_H_ */

--- a/src/translate.h
+++ b/src/translate.h
@@ -73,4 +73,24 @@
 	: "Choose an action in the menu, or close it..." \
 )
 
+#define LBL_ABOUT_MAIN_DESCRIPTION (IS_LANG_FR \
+	? "Une application Wallabag pour liseuses Pocketbook Touch Lux." \
+	: "A Wallabag application for Pocketbook Touch Lux ereaders." \
+)
+
+#define LBL_ABOUT_DEVELOPED_BY_PM (IS_LANG_FR \
+	? "Développé par Pascal MARTIN." \
+	: "Developed by Pascal MARTIN." \
+)
+
+#define LBL_ABOUT_CONTRIBUTE (IS_LANG_FR \
+	? "Contribuer (GPL-3.0) :" \
+	: "Contribute (GPL-3.0):" \
+)
+
+#define LBL_STATUSBAR_FEEL_FREE_TO_CONTRIBUTE (IS_LANG_FR \
+	? "N'hésitez pas à contribuer sur %s ;-)" \
+	: "Feel free to contribute on %s ;-)" \
+)
+
 #endif /* SRC_TRANSLATE_H_ */

--- a/src/translate.h
+++ b/src/translate.h
@@ -163,4 +163,64 @@
 	: "Loading reader app for entry#%1$d (%3$s) - %2$s..." \
 )
 
+#define LBL_AFTERREAD_ACTIONONENTRY_WHAT_TO_DO_WITH_ENTRY_CONTENT (IS_LANG_FR \
+	? "Que voulez-vous faire de #%d?\n%.128s?" \
+	: "What do you want to do with entry #%d?\n%.128s?" \
+)
+
+#define LBL_AFTERREAD_ACTIONONENTRY_WHAT_TO_DO_WITH_ENTRY_TITLE (IS_LANG_FR \
+	? "Et maintenant ?" \
+	: "What now with this entry?" \
+)
+
+#define LBL_AFTERREAD_ACTIONONENTRY_BUTTON_ARCHIVE (IS_LANG_FR \
+	? "Archiver" \
+	: "Archive" \
+)
+
+#define LBL_AFTERREAD_ACTIONONENTRY_BUTTON_ARCHIVE_STAR (IS_LANG_FR \
+	? "Archiver + Étoiler" \
+	: "Archive + Star" \
+)
+
+#define LBL_AFTERREAD_ACTIONONENTRY_BUTTON_ARCHIVE_UNSTAR (IS_LANG_FR \
+	? "Archiver + Dés-étoiler" \
+	: "Archive + Un-star" \
+)
+
+#define LBL_AFTERREAD_ACTIONONENTRY_BUTTON_UNARCHIVE (IS_LANG_FR \
+	? "Dés-archiver" \
+	: "Un-archive" \
+)
+
+#define LBL_AFTERREAD_ACTIONONENTRY_BUTTON_UNARCHIVE_STAR (IS_LANG_FR \
+	? "Dés-archiver + Étoiler" \
+	: "Un-archive + Star" \
+)
+
+#define LBL_AFTERREAD_ACTIONONENTRY_BUTTON_UNARCHIVE_UNSTAR (IS_LANG_FR \
+	? "Dés-archiver + Dés-étoiler" \
+	: "Un-archive + Un-star" \
+)
+
+#define LBL_AFTERREAD_ACTIONONENTRY_BUTTON_DONOTHING (IS_LANG_FR \
+	? "Ne rien faire" \
+	: "Do nothing" \
+)
+
+#define LBL_STATUSBAR_AFTERREAD_THANKS_READ_ANOTHER (IS_LANG_FR \
+	? "Merci ! Vous pouvez maintenant lire une autre entrée ;-)" \
+	: "Thanks! You can read another entry, now ;-)" \
+)
+
+#define LBL_STATUSBAR_AFTERREAD_CHANGE_SENT_ON_NEXT_SYNC (IS_LANG_FR \
+	? "Ce changement sera envoyé au serveur à la prochaine synchronisation." \
+	: "This change will be sent to the server next time you synchronize." \
+)
+
+#define LBL_STATUSBAR_AFTERREAD_WHAT_TO_DO_WITH_ENTRY (IS_LANG_FR \
+	? "Choisissez quoi faire de l'entrée que vous venez de lire..." \
+	: "Choose what to do with the entry you've just read..." \
+)
+
 #endif /* SRC_TRANSLATE_H_ */

--- a/src/translate.h
+++ b/src/translate.h
@@ -143,4 +143,9 @@
 	: "Loading reader app for entry#%1$d - %2$s..." \
 )
 
+#define LBL_STATUSBAR_OPENING_CONTEXTMENU_FOR_ENTRY (IS_LANG_FR \
+	? "Ouverture du menu contextuel pour #%1$d - %2$s..." \
+	: "Opening context menu for entry#%1$d - %2$s..." \
+)
+
 #endif /* SRC_TRANSLATE_H_ */

--- a/src/translate.h
+++ b/src/translate.h
@@ -43,4 +43,29 @@
 	: "Use [<] and [>] keys to navigate. Touch an entry to read it." \
 )
 
+#define LBL_MAINMENU_MODE_UNREAD_ENTRIES (IS_LANG_FR \
+	? "Afficher les entrées non lues" \
+	: "Display unread entries" \
+)
+
+#define LBL_MAINMENU_MODE_ARCHIVED_ENTRIES (IS_LANG_FR \
+	? "Afficher les entrées archivées" \
+	: "Display archived entries" \
+)
+
+#define LBL_MAINMENU_MODE_STARRED_ENTRIES (IS_LANG_FR \
+	? "Afficher les entrées étoilées" \
+	: "Display starred entries" \
+)
+
+#define LBL_MAINMENU_DELETE_ALL_LOCAL_DATA (IS_LANG_FR \
+	? "Supprimer toutes les données locales" \
+	: "Delete all local data" \
+)
+
+#define LBL_MAINMENU_ABOUT (IS_LANG_FR \
+	? "À propos" \
+	: "About" \
+)
+
 #endif /* SRC_TRANSLATE_H_ */

--- a/src/translate.h
+++ b/src/translate.h
@@ -318,4 +318,29 @@ extern int global_lang;
 	: "Could not load entries from server: server returned status code: " \
 )
 
+#define LBL_SYNC_DIALOG_TITLE (IS_LANG_FR \
+	? "Synchronisation avec le serveur" \
+	: "Synchronizing with server" \
+)
+
+#define LBL_SYNC_START_SYNC (IS_LANG_FR \
+	? "Lancement de la synchronisation..." \
+	: "Starting synchronization" \
+)
+
+#define LBL_SYNC_FETCHING_RECENT_ENTRIES (IS_LANG_FR \
+	? "Téléchargement des entrées récentes..." \
+	: "Fetching recent entries from server" \
+)
+
+#define LBL_SYNC_FAILED_TOO_BAD (IS_LANG_FR \
+	? "Dommage ;-(" \
+	: "Too bad ;-(" \
+)
+
+#define LBL_SYNC_SUCCESS_DONE (IS_LANG_FR \
+	? "Synchronisation terminée \\o/" \
+	: "All done \\o/" \
+)
+
 #endif /* SRC_TRANSLATE_H_ */

--- a/src/translate.h
+++ b/src/translate.h
@@ -93,4 +93,34 @@
 	: "Feel free to contribute on %s ;-)" \
 )
 
+#define LBL_DELETEALL_DIALOG_TITLE (IS_LANG_FR \
+	? "Supprimer toutes les données locales ?" \
+	: "Delete all local data?" \
+)
+
+#define LBL_DELETEALL_DIALOG_CONTENT (IS_LANG_FR \
+	? "Voulez-vous vraiment supprimer toutes les données locales ?\nVous devrez synchroniser depuis le serveur pour obtenir de nouvelles données.\nLes données modifiées localement et non synchronisées vers le serveur seront perdues.." \
+	: "Do you really want to delete all local data?\nYou will need to sync from server to fetch new data.\nData updated locally and not already synced to server will be lost." \
+)
+
+#define LBL_DELETEALL_DIALOG_BTN_OK (IS_LANG_FR \
+	? "Supprimer les données" \
+	: "Delete local data" \
+)
+
+#define LBL_DELETEALL_DIALOG_BTN_CANCEL (IS_LANG_FR \
+	? "Annuler" \
+	: "Cancel" \
+)
+
+#define LBL_STATUSBAR_DELETEALL_DONE (IS_LANG_FR \
+	? "Données locales supprimées. Lance une synchro pour obtenir des données depuis le serveur ;-)" \
+	: "Local data deleted. You should now run a sync to fetch data from server ;-)" \
+)
+
+#define LBL_STATUSBAR_DELETEALL_CANCELED (IS_LANG_FR \
+	? "Données locales non modifiées." \
+	: "Local data has been left untouched." \
+)
+
 #endif /* SRC_TRANSLATE_H_ */

--- a/src/translate.h
+++ b/src/translate.h
@@ -1,7 +1,12 @@
 #ifndef SRC_TRANSLATE_H_
 #define SRC_TRANSLATE_H_
 
-#define IS_LANG_FR (true)
+#define LANG_EN 0
+#define LANG_FR 1
+
+extern int global_lang;
+
+#define IS_LANG_FR (global_lang == LANG_FR)
 
 #define LBL_HEADER_UNREAD_ENTRIES (IS_LANG_FR \
 	? "entrées non lues" \

--- a/src/translate.h
+++ b/src/translate.h
@@ -148,4 +148,19 @@
 	: "Opening context menu for entry#%1$d - %2$s..." \
 )
 
+#define LBL_ENTRY_CONTEXTMENU_READ_HTML (IS_LANG_FR \
+	? "Lire le contenu HTML" \
+	: "Read HTML content" \
+)
+
+#define LBL_ENTRY_CONTEXTMENU_READ_EPUB (IS_LANG_FR \
+	? "Lire la version EPUB" \
+	: "Read EPUB version" \
+)
+
+#define LBL_STATUSBAR_OPENING_READERAPP_FOR_ENTRY_FORMAT (IS_LANG_FR \
+	? "Chargement de l'appli de lecture pour #%1$d (%3$s) - %2$s..." \
+	: "Loading reader app for entry#%1$d (%3$s) - %2$s..." \
+)
+
 #endif /* SRC_TRANSLATE_H_ */


### PR DESCRIPTION
With this PR :

 * Very crude translation mechanism (based on ugly macros, yeah)
 * EN + FR strings
 * We can set `"lang": "fr"` in `config.json` to use the app in French (default is still English)

It's not *perfect* but should be enough for now ;-)
Also: I might have forgotten a string here and there... If so, they'll be fixed / translated on the go when I see them.

fix #27