### PR TITLE
Migration 006: add an index on entries.local_is_archived+remote_created_at

### DIFF
--- a/src/database/database.h
+++ b/src/database/database.h
@@ -46,6 +46,7 @@ private:
 	void migration_003_createIndexesOnEntries();
 	void migration_004_createEpubDownloadQueueTable();
 	void migration_005_addIsEmptyFieldOnEntries();
+	void migration_006_createIndexSortForDisplayingListOnEntries();
 
 	void insertInternal(std::string key, std::string value);
 	void updateInternal(std::string key, std::string value);


### PR DESCRIPTION
This speeds up the list of entries a lot, especially when there are many entries on the device.
fix #94
