### PR TITLE
[Fixes #93] Disable logging by default

### DIFF
--- a/src/log.cpp
+++ b/src/log.cpp
@@ -1,6 +1,6 @@
 #include "log.h"
 
-#include <fstream>
+#include <sys/stat.h>
 
 #include "main.h"
 
@@ -17,8 +17,8 @@ static std::string replaceAll(std::string subject, const std::string& search, co
 
 void Log::init()
 {
-	std::ifstream infile(FILEACTIVE);
-	if( infile.good() ) {
+	struct stat buffer;
+	if( stat(FILEACTIVE, &buffer) == 0) {
 		_logActive = 1;
 	} else {
 		_logActive = 0;

--- a/src/log.h
+++ b/src/log.h
@@ -25,12 +25,16 @@ public:
 		return instance;
 	}
 
+	void init();
+
 	Log(Log const&) = delete;
 	void operator=(Log const&) = delete;
 
 private:
 	const char *DIR = FLASHDIR;
 	const char *FILEPATH = FLASHDIR "/plop-reader-logs.html";
+	const char *FILEACTIVE = FLASHDIR "/plop-reader-activate-log.txt";
+	int _logActive = 1;
 
 	Log() {};
 	~Log() {};

--- a/src/log.h
+++ b/src/log.h
@@ -36,7 +36,9 @@ private:
 	const char *FILEACTIVE = FLASHDIR "/plop-reader-activate-log.txt";
 	int _logActive = 1;
 
-	Log() {};
+	Log() {
+		init();
+	};
 	~Log() {};
 };
 


### PR DESCRIPTION
Log can be activated by creating a file named `plop-reader-activate-log.txt` at the root of the mounted disk of you reader.