### PR TITLE
Long entries filter

### DIFF
--- a/src/application.cpp
+++ b/src/application.cpp
@@ -1,20 +1,6 @@
 #include "application.h"
 #include "log.h"
-
-
-#include <string>
-#include <sstream>
-
-namespace patch
-{
-    template < typename T > std::string to_string( const T& n )
-    {
-        std::ostringstream stm ;
-        stm << n ;
-        return stm.str() ;
-    }
-}
-
+#include "utils.cpp"
 
 
 void Application::init()
@@ -499,8 +485,8 @@ void Application::restoreModeAndPage()
 
 void Application::saveModeAndPage()
 {
-	getDb().saveInternal("gui.pageNum", patch::to_string(pageNum));
-	getDb().saveInternal("gui.mode", patch::to_string(mode));
+	getDb().saveInternal("gui.pageNum", utils::to_string(pageNum));
+	getDb().saveInternal("gui.mode", utils::to_string(mode));
 }
 
 

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -386,6 +386,9 @@ int Application::countEntriesForCurrentMode()
 	if (mode == MODE_STARRED) {
 		return entryRepository.countStarred();
 	}
+	if (mode == MODE_LONG) {
+		return entryRepository.countLong();
+	}
 	return 0;
 }
 
@@ -400,6 +403,9 @@ void Application::listEntriesForCurrentMode(std::vector<Entry> &entries)
 	}
 	else if (mode == MODE_STARRED) {
 		entryRepository.listStarred(entries, numPerPage, (pageNum-1) * numPerPage);
+	}
+	else if (mode == MODE_LONG) {
+		entryRepository.listLong(entries, numPerPage, (pageNum-1) * numPerPage);
 	}
 }
 

--- a/src/application.h
+++ b/src/application.h
@@ -27,7 +27,7 @@
 class Application
 {
 public:
-	enum entries_mode {MODE_UNREAD=1, MODE_ARCHIVED, MODE_STARRED};
+	enum entries_mode {MODE_UNREAD=1, MODE_ARCHIVED, MODE_STARRED, MODE_LONG};
 	enum reading_format {FORMAT_HTML=1, FORMAT_EPUB};
 
 	Application() : entryRepository(db), epubDownloadQueueRepository(db), gui(*this) {

--- a/src/gui/gui.cpp
+++ b/src/gui/gui.cpp
@@ -125,6 +125,9 @@ void Gui::show(int numPage, int numberOfPages, int countAllEntries, std::vector<
 	else if (mode == 3) {
 		snprintf(buffer, sizeof(buffer), PLOP_APPLICATION_FULLNAME " - %s", LBL_HEADER_STARRED_ENTRIES);
 	}
+	else if (mode == 4) {
+		snprintf(buffer, sizeof(buffer), PLOP_APPLICATION_FULLNAME " - %s", LBL_HEADER_LONG_ENTRIES);
+	}
 	else {
 		snprintf(buffer, sizeof(buffer), PLOP_APPLICATION_FULLNAME);
 	}
@@ -231,6 +234,7 @@ void Gui::displayMainMenu()
 	const char *str3 = LBL_MAINMENU_MODE_STARRED_ENTRIES;
 	const char *str_reset = LBL_MAINMENU_DELETE_ALL_LOCAL_DATA;
 	const char *str4 = LBL_MAINMENU_ABOUT;
+	const char *str5 = LBL_MAINMENU_MODE_LONG_ENTRIES;
 
 	menu = (imenuex *)calloc(7, sizeof(imenuex));
 
@@ -275,6 +279,13 @@ void Gui::displayMainMenu()
 	menu[5].icon = LoadPNG(PLOP_ICON_HELP_PATH, 1);
 	menu[5].font = NULL;
 	menu[5].submenu = NULL;
+
+	menu[6].type = 2;
+	menu[6].index = 6;
+	menu[6].text = (char *)str5;
+	menu[6].icon = NULL;
+	menu[6].font = NULL;
+	menu[6].submenu = &menu[5];
 
 	auto callback = [](int index) {
 		free(menu);
@@ -328,6 +339,9 @@ void Gui::displayMainMenu()
 			else if (result == 2) {
 				app.getGui().statusBarText(LBL_STATUSBAR_DELETEALL_CANCELED);
 			}
+		}
+		else if (index == 6) {
+			app.setMode(Application::MODE_LONG);
 		}
 	};
 

--- a/src/repositories/entry_repository.cpp
+++ b/src/repositories/entry_repository.cpp
@@ -1,5 +1,6 @@
 #include "entry_repository.h"
 
+#include "../utils.cpp"
 
 // TODO a lot of error-handling around database manipulations
 
@@ -208,24 +209,29 @@ void EntryRepository::deleteAll()
 
 void EntryRepository::listUnread(std::vector<Entry> &entries, int limit, int offset)
 {
-	return list(entries, limit, offset, 0, 1);
+	return list(entries, limit, offset, 0, 1, -1);
 }
 
 
 void EntryRepository::listArchived(std::vector<Entry> &entries, int limit, int offset)
 {
-	return list(entries, limit, offset, 2, 1);
+	return list(entries, limit, offset, 2, 1, -1);
 }
 
 
 void EntryRepository::listStarred(std::vector<Entry> &entries, int limit, int offset)
 {
-	return list(entries, limit, offset, 1, 2);
+	return list(entries, limit, offset, 1, 2, -1);
+}
+
+void EntryRepository::listLong(std::vector<Entry> &entries, int limit, int offset)
+{
+	return list(entries, limit, offset, 0, 1, 600);
 }
 
 
 void EntryRepository::list(std::vector<Entry> &entries, int limit, int offset,
-		int archived, int starred
+		int archived, int starred, int reading_time = -1
 )
 {
 	entries.clear();
@@ -252,6 +258,10 @@ void EntryRepository::list(std::vector<Entry> &entries, int limit, int offset,
 	else if (starred == 2) {
 		conditions.push_back("local_is_starred = 1");
 	}
+
+        if (reading_time != -1) {
+                conditions.push_back("reading_time >= " + utils::to_string(reading_time));
+        }
 
 	//conditions.push_back("is_empty = 0");
 
@@ -351,21 +361,26 @@ offset :offset
 
 int EntryRepository::countUnread()
 {
-	return count(0, 1);
+	return count(0, 1, -1);
 }
 
 int EntryRepository::countArchived()
 {
-	return count(2, 1);
+	return count(2, 1, -1);
 }
 
 int EntryRepository::countStarred()
 {
-	return count(1, 2);
+	return count(1, 2, -1);
+}
+
+int EntryRepository::countLong()
+{
+	return count(0, 1, 600);
 }
 
 
-int EntryRepository::count(int archived, int starred)
+int EntryRepository::count(int archived, int starred, int reading_time = -1)
 {
 	std::vector<std::string> conditions;
 
@@ -388,6 +403,10 @@ int EntryRepository::count(int archived, int starred)
 	else if (starred == 2) {
 		conditions.push_back("local_is_starred = 1");
 	}
+
+        if (reading_time != -1) {
+                conditions.push_back("reading_time >= " + utils::to_string(reading_time));
+        }
 
 	const char *sqlTemplate = "select count(*) from entries %s";
 

--- a/src/repositories/entry_repository.h
+++ b/src/repositories/entry_repository.h
@@ -18,18 +18,20 @@ public:
 	void deleteAll();
 
 	void list(std::vector<Entry> &entries, int limit, int offset,
-			int archived, int starred);
+			int archived, int starred, int reading_time);
 
 	int countAllEntries();
 
 	int countUnread();
 	int countArchived();
 	int countStarred();
-	int count(int archived, int starred);
+	int countLong();
+	int count(int archived, int starred, int reading_time);
 
 	void listUnread(std::vector<Entry> &entries, int limit, int offset);
 	void listArchived(std::vector<Entry> &entries, int limit, int offset);
 	void listStarred(std::vector<Entry> &entries, int limit, int offset);
+	void listLong(std::vector<Entry> &entries, int limit, int offset);
 
 	Entry get(int entryId);
 	Entry findByRemoteId(int remoteId);

--- a/src/translate.h
+++ b/src/translate.h
@@ -23,6 +23,11 @@ extern int global_lang;
 	: "starred entries" \
 )
 
+#define LBL_HEADER_LONG_ENTRIES (IS_LANG_FR \
+	? "Longs articles" \
+	: "Long entries" \
+)
+
 #define LBL_HEADER_PAGE_NUM (IS_LANG_FR \
 	? "Page %1$d / %2$d (%3$d entrées)" \
 	: "Page %1$d / %2$d (%3$d entries)" \
@@ -61,6 +66,11 @@ extern int global_lang;
 #define LBL_MAINMENU_MODE_STARRED_ENTRIES (IS_LANG_FR \
 	? "Afficher les entrées étoilées" \
 	: "Display starred entries" \
+)
+
+#define LBL_MAINMENU_MODE_LONG_ENTRIES (IS_LANG_FR \
+	? "Lecture > 10 min" \
+	: "Reading > 10mn" \
 )
 
 #define LBL_MAINMENU_DELETE_ALL_LOCAL_DATA (IS_LANG_FR \

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,12 @@
+#include <string>
+#include <sstream>
+
+namespace utils
+{
+    template < typename T > std::string to_string( const T& n )
+    {
+        std::ostringstream stm ;
+        stm << n ;
+        return stm.str() ;
+    }
+}


### PR DESCRIPTION
I'm reading short entries on my phone and just like the Touch Lux comfort for long entries so I added a filter for entries longer than 10 minutes.

We could improve this PR with a nice icon and maybe a better entry menu position. I'm not a CPP developer so maybe my `utils.cpp` is wrong. Let me know.

Have a nice day.